### PR TITLE
Application hide, download bounce, menu bar, about prose

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -44,8 +44,8 @@ fn main() {
 
                 api.prevent_close();
             }
-            WindowEvent::Focused(focus) => {
-                event.window().emit("window-focused", focus).unwrap()
+            WindowEvent::Focused(focused) => {
+                event.window().emit("window-focused", focused).unwrap()
             }
             _ => {}
         })

--- a/src/assemblies/inbox/InboxMessaging.vue
+++ b/src/assemblies/inbox/InboxMessaging.vue
@@ -1589,8 +1589,8 @@ export default {
               event.file.url,
               event.file.name,
               (actual, total) => {
-                let percent = Math.round(actual / total * 100)
-                console.log(`${percent}% done`)
+                let percent = Math.round((actual / total) * 100);
+                console.log(`${percent}% done`);
               }
             );
 


### PR DESCRIPTION
1. ✅ When application is closed by hiding, it still thinks it has focus (so it marks any unread as read) — same if minimized
2. ☑️ Make Download folder bounce when download is done
3. ☑️ Menu bar for macOS (Settings + Profile buttons, Check for Updates et al)
4. ☑️ About Prose.app window for macOS (fill it with Prose website and details)

progress

1. ✅ See if window is in focus (both web and Tauri)

```js
UtilitiesRuntime.registerWindowFocusCallback((focus) => console.log("focus: " + focus))
```