### PR TITLE
Setting quarantine flag on download

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,10 @@ objc = "0.2.7"
 percent-encoding = "2.3.1"
 mac-notification-sys = "0.6.1"
 window-vibrancy = "0.4.3"
+# this 3 crates are for macOS only to set quarantine flag
+extattr = "1.0.0"
+uuid = { version = "1.8.0", features = ["v4"] }
+libc = "0.2.153"
 notifications = { path = "crates/notifications" }
 
 [features]

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -29,6 +29,8 @@ pub enum DownloadError {
     CouldNotCreateFile,
     #[error("Could not download file")]
     DownloadError,
+    #[error("Custom error")]
+    CustomError(String),
 }
 
 /**************************************************************************
@@ -102,6 +104,12 @@ pub async fn download_file<R: Runtime>(
     let mut file = File::create(&download_path)
         .await
         .map_err(|_| DownloadError::CouldNotCreateFile)?;
+
+    #[cfg(target_os = "macos")]
+    {
+        mac_set_quarantine(&file, "Prose")
+            .map_err(|e| DownloadError::CustomError(e.to_string()))?;
+    }
 
     // Compute total download size
     let total_bytes = response.content_length().unwrap_or(0) as usize;
@@ -194,6 +202,40 @@ fn remove_path_traversal(filename: &str) -> String {
         .replace(|c| c < ' ', "")
         .replace(['/', '\\', ':', '~', '@', '?', '[', ']'], "")
         .replace("..", "")
+}
+// need to set quarantine flag that user can't just open downloaded file if it's an app
+// https://apple.stackexchange.com/questions/256625/how-to-set-restore-the-com-apple-quarantine-attribute
+#[cfg(target_os = "macos")]
+fn mac_set_quarantine(file: &File, application: &str) -> Result<(), std::io::Error> {
+    use std::ffi::{c_void, CString};
+    use std::os::fd::AsRawFd;
+    use std::time::SystemTime;
+    use uuid::Uuid;
+
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let value = format!("0081;{:x};{};{}", timestamp, application, Uuid::new_v4());
+    let name = CString::new("com.apple.quarantine").unwrap();
+    let value = value.as_bytes();
+    let len = value.len();
+    let value = value.as_ptr() as *const c_void;
+
+    let ret = unsafe {
+        libc::fsetxattr(
+            file.as_raw_fd(),
+            name.as_ptr(),
+            value,
+            len,
+            0,
+            libc::XATTR_CREATE,
+        )
+    };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 /**************************************************************************


### PR DESCRIPTION
setting `com.apple.quarantine` so if user downloads .dmg or any kind of executable, MacOS stops user form opening it directly without warning

#96 