### PR TITLE
Friendlier analytics

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -3,7 +3,7 @@
 
   "overrides": {
     "allowInsecure": true,
-    "disableTracking": true,
+    "disableAnalytics": true,
 
     "hostMeta": {
       "prose.org.local": {

--- a/src/components/sidebar/SidebarContext.vue
+++ b/src/components/sidebar/SidebarContext.vue
@@ -159,9 +159,9 @@ import { useEvents } from "@/composables/events";
 
 // PROJECT: UTILITIES
 import {
-  default as UtilitiesTracking,
-  TrackingEventName
-} from "@/utilities/tracking";
+  default as UtilitiesAnalytics,
+  AnalyticsEventName
+} from "@/utilities/analytics";
 
 // PROJECT: BROKER
 import Broker from "@/broker";
@@ -771,8 +771,8 @@ export default {
     async onModalSignOutProceed(
       options: SignOutEventProceedOptions
     ): Promise<void> {
-      // Track action
-      UtilitiesTracking.event(TrackingEventName.AccountSignout);
+      // Record action
+      UtilitiesAnalytics.event(AnalyticsEventName.AccountSignout);
 
       // Logout from account
       await Store.$account.logout(options.purge);

--- a/src/popups/sidebar/EditProfile.vue
+++ b/src/popups/sidebar/EditProfile.vue
@@ -90,9 +90,9 @@ import { SaveAvatarRequest } from "@/broker/modules/profile";
 
 // PROJECT: UTILITIES
 import {
-  default as UtilitiesTracking,
-  TrackingEventName
-} from "@/utilities/tracking";
+  default as UtilitiesAnalytics,
+  AnalyticsEventName
+} from "@/utilities/analytics";
 
 // TYPES
 type FormValueString = { inner: string };
@@ -383,8 +383,8 @@ export default {
       if (this.fetching !== true && this.saving !== true) {
         this.saving = true;
 
-        // Track action
-        UtilitiesTracking.event(TrackingEventName.ProfileUpdate);
+        // Record action
+        UtilitiesAnalytics.event(AnalyticsEventName.ProfileUpdate);
 
         // Apply forms in store
         this.formsToStoreApply(this.contentSections.profile.properties.form);

--- a/src/utilities/analytics.ts
+++ b/src/utilities/analytics.ts
@@ -28,7 +28,7 @@ import CONFIG from "@/commons/config";
  * ENUMERATIONS
  * ************************************************************************* */
 
-export enum TrackingEventName {
+export enum AnalyticsEventName {
   // App Heartbeat.
   AppHeartbeat = "app:heartbeat",
   // Account Signin.
@@ -43,24 +43,24 @@ export enum TrackingEventName {
  * INTERFACES
  * ************************************************************************* */
 
-interface TrackingEventPayload {
-  name: TrackingEventName;
+interface AnalyticsEventPayload {
+  name: AnalyticsEventName;
   data?: object;
-  origin: TrackingEventOrigin;
+  origin: AnalyticsEventOrigin;
 }
 
-interface TrackingEventOrigin {
-  app: TrackingEventOriginApp;
-  pod: TrackingEventOriginPod;
+interface AnalyticsEventOrigin {
+  app: AnalyticsEventOriginApp;
+  pod: AnalyticsEventOriginPod;
 }
 
-interface TrackingEventOriginApp {
+interface AnalyticsEventOriginApp {
   name: string;
   version: string;
   platform: string;
 }
 
-interface TrackingEventOriginPod {
+interface AnalyticsEventOriginPod {
   domain_hash: string;
   user_hash?: string;
 }
@@ -74,11 +74,11 @@ const EVENT_NAME_NEXT_SEND_DELAY = 3000; // 3 seconds
 const ANONYMIZED_USER_IDENTIFIER_SHORT_LENGTH = 16; // 16 characters
 
 /**************************************************************************
- * TRACKING
+ * ANALYTICS
  * ************************************************************************* */
 
-class UtilitiesTracking {
-  private readonly __eventOriginApp: TrackingEventOriginApp;
+class UtilitiesAnalytics {
+  private readonly __eventOriginApp: AnalyticsEventOriginApp;
 
   private __eventsNextAllowedSendRegister: { [name: string]: number };
 
@@ -90,28 +90,28 @@ class UtilitiesTracking {
     this.__eventsNextAllowedSendRegister = {};
   }
 
-  event(name: TrackingEventName, data?: object): void {
-    // User did not opt-out of tracking reports? Dispatch event.
+  event(name: AnalyticsEventName, data?: object): void {
+    // User did not opt-out of analytics? Dispatch event.
     if (Store.$settings.privacy.report.tracking !== false) {
       // Notice: do not await here, since the 'event()' helper wraps \
       //   asynchronous code in synchronous-looking code. We should never wait \
-      //   for a tracking event dispatch to be complete (it is pointless). We \
+      //   for an analytics event dispatch to be complete (it is pointless). We \
       //   therefore avoid developer mistakes by marking this method as \
       //   synchronous, since developers will not await it by mistake in \
       //   caller code.
       this.__dispatchEvent(name, data);
     } else {
-      logger.debug(`Skipped sending tracking event: '${name}' (opted out)`);
+      logger.debug(`Skipped sending analytics event: '${name}' (opted out)`);
     }
   }
 
   private async __dispatchEvent(
-    name: TrackingEventName,
+    name: AnalyticsEventName,
     data?: object
   ): Promise<void> {
     try {
       // Generate event data
-      const eventData: TrackingEventPayload = {
+      const eventData: AnalyticsEventPayload = {
         name,
 
         origin: this.__makeEventOrigin()
@@ -121,11 +121,11 @@ class UtilitiesTracking {
         eventData.data = data;
       }
 
-      logger.debug(`Sending tracking event: '${name}'...`, eventData);
+      logger.debug(`Sending analytics event: '${name}'...`, eventData);
 
-      // Tracking is disabled by override?
-      if (CONFIG.overrides?.disableTracking === true) {
-        throw new Error("Tracking disabled by override");
+      // Analytics are disabled by override?
+      if (CONFIG.overrides?.disableAnalytics === true) {
+        throw new Error("Analytics disabled by override");
       }
 
       // Acquire current time and next send time
@@ -140,10 +140,10 @@ class UtilitiesTracking {
       this.__eventsNextAllowedSendRegister[name] =
         nowTime + EVENT_NAME_NEXT_SEND_DELAY;
 
-      // Send anonymized event to tracking endpoint
+      // Send anonymized event to analytics endpoint
       // Important: if the user has opted-out of anonymous analytics, then do \
       //   not post ANY event to this endpoint (honor user choices).
-      const trackingResponse = await fetch(
+      const analyticsResponse = await fetch(
         `${CONFIG.url.proseWeb}/_api/cloud/v1/analytics/event`,
         {
           method: "POST",
@@ -157,20 +157,20 @@ class UtilitiesTracking {
         }
       );
 
-      if (trackingResponse.ok !== true) {
-        throw new Error("Tracking request failed");
+      if (analyticsResponse.ok !== true) {
+        throw new Error("Analytics request failed");
       }
 
-      logger.info(`Sent tracking event: '${name}'`);
+      logger.info(`Sent analytics event: '${name}'`);
     } catch (error) {
       logger.info(
-        `Could not track event: '${name}'`,
+        `Could not record analytics event: '${name}'`,
         (error as Error)?.message || error
       );
     }
   }
 
-  private __makeEventOrigin(): TrackingEventOrigin {
+  private __makeEventOrigin(): AnalyticsEventOrigin {
     // Acquire self JID
     const selfJID = Store.$account.getSelfJID();
 
@@ -195,7 +195,7 @@ class UtilitiesTracking {
     throw new Error("Incomplete origin data");
   }
 
-  private __prepareEventOriginApp(): TrackingEventOriginApp {
+  private __prepareEventOriginApp(): AnalyticsEventOriginApp {
     // Acquire app name from package name, which might be namespaced, eg. \
     //   '@namespace/project-name', or directly named eg. 'project-name'.
     return Object.freeze({
@@ -222,4 +222,4 @@ class UtilitiesTracking {
  * EXPORTS
  * ************************************************************************* */
 
-export default new UtilitiesTracking();
+export default new UtilitiesAnalytics();

--- a/src/utilities/tracking.ts
+++ b/src/utilities/tracking.ts
@@ -144,7 +144,7 @@ class UtilitiesTracking {
       // Important: if the user has opted-out of anonymous analytics, then do \
       //   not post ANY event to this endpoint (honor user choices).
       const trackingResponse = await fetch(
-        `${CONFIG.url.proseWeb}/_api/cloud/v1/track/event`,
+        `${CONFIG.url.proseWeb}/_api/cloud/v1/analytics/event`,
         {
           method: "POST",
           headers: {

--- a/src/utilities/tracking.ts
+++ b/src/utilities/tracking.ts
@@ -176,7 +176,9 @@ class UtilitiesTracking {
 
     // Anonymize self JID
     const domainHash = this.__anonymizeUserIdentifier(selfJID.domain),
-      userHash = this.__anonymizeUserIdentifier(selfJID.node);
+      // NOTE: Use full JID as user identifier so it contains a random part
+      //   (prevents re-identification).
+      userHash = this.__anonymizeUserIdentifier(selfJID.toString());
 
     // Do we have sufficient information on the current user? Generate origin
     if (domainHash !== undefined && userHash !== undefined) {

--- a/src/views/app/AppBase.vue
+++ b/src/views/app/AppBase.vue
@@ -37,9 +37,9 @@ import AppSidebar from "@/assemblies/app/AppSidebar.vue";
 
 // PROJECT: UTILITIES
 import {
-  default as UtilitiesTracking,
-  TrackingEventName
-} from "@/utilities/tracking";
+  default as UtilitiesAnalytics,
+  AnalyticsEventName
+} from "@/utilities/analytics";
 
 // CONSTANTS
 const HEARTBEAT_REPORTING_TICK_INITIAL_DELAY = 30000; // 30 seconds
@@ -93,8 +93,8 @@ export default {
       //   the final work.
       this.heartbeatReportingTickTimeout = setWorkerTimeout(
         () => {
-          // Track liveness
-          UtilitiesTracking.event(TrackingEventName.AppHeartbeat);
+          // Record liveness
+          UtilitiesAnalytics.event(AnalyticsEventName.AppHeartbeat);
         },
 
         initial === true ? HEARTBEAT_REPORTING_TICK_INITIAL_DELAY : 0

--- a/src/views/start/StartLogin.vue
+++ b/src/views/start/StartLogin.vue
@@ -55,9 +55,9 @@ import {
   translucent as runtimeTranslucent
 } from "@/utilities/runtime";
 import {
-  default as UtilitiesTracking,
-  TrackingEventName
-} from "@/utilities/tracking";
+  default as UtilitiesAnalytics,
+  AnalyticsEventName
+} from "@/utilities/analytics";
 
 // CONSTANTS
 const INTERFACE_WIDTH = 600;
@@ -98,10 +98,10 @@ export default {
         try {
           await Store.$account.login(form.jid, form.password, form.remember);
 
-          // Track action
+          // Record action
           // Important: AFTER login, that way we can properly identify the \
-          //   user in the tracking event.
-          UtilitiesTracking.event(TrackingEventName.AccountSignin);
+          //   user in the analytics event.
+          UtilitiesAnalytics.event(AnalyticsEventName.AccountSignin);
 
           // Show success alert
           BaseAlert.success("Authenticated", "Welcome back!");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,7 @@ interface Configuration {
 
   overrides?: {
     allowInsecure?: boolean;
-    disableTracking?: boolean;
+    disableAnalytics?: boolean;
 
     hostMeta?: {
       [domain: string]: {


### PR DESCRIPTION
Although we added analytics with good intentions and cared about not collecting personal information, people still got scared by the recent addition of “tracking”.

This pull request introduces multiple things:

1. User identifiers are now derived from full JIDs and not just XMPP usernames. This means user IDs are now random (JID resourceparts are random) and not shared across devices. We’ll see each device as a different user, removing our ability to count users for a given domain or analyze user behaviors across devices. We weren’t doing it, but now you are assured of it.
2. When Prose is used with a backing Prose Pod Server, analytics events are sent to it so it acts as an anonymizing proxy (so we don’t even see users’ IP addresses). We even went the extra mile and [made the Prose Pod Server re-anonymize user identifiers with a random salt](https://github.com/prose-im/prose-pod-server/commit/154ae597eaa29557acd12cc757d5d659e9f78384#diff-cf6c1c741793ca26f9b6f8e87bd06aad84db0b711a75905ccdaf599f1ed12402R184-R189) so no one can ever associate an analytics identifier to a user.
3. All “tracking” terminology has been removed from the code, as we’re not even tracking users (we can’t). Using such terms was a mistake in the first place. I haven’t migrated the settings to make sure nothing breaks so the term “tracking” is still there, but we’ll get rid of it someday™.
